### PR TITLE
Restrict incoming traffic by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,19 @@ box-%: export TF_VAR_name ?= $(shell echo ${USER} | tr '[:upper:]' '[:lower:]')-
 box-%: export TF_VAR_user ?= ${USER}
 box-%: export TF_VAR_serviceaccount_file ?= $(REPO_ROOT)/secrets/gardener-dev.json
 
+# restrict incoming traffic to dev box to the outgoing IPv4 address of the local device by default
+RESTRICT_SOURCE_RANGES ?= yes
+ifneq ($(RESTRICT_SOURCE_RANGES),no)
+box-%: export TF_VAR_source_ranges ?= ["$(shell curl -sS --ipv4 https://ifconfig.me)/32"]
+endif
+
 .PHONY: box-up
 box-up: $(TERRAFORM)
 	$(TERRAFORM) -chdir=$(TERRAFORM_DIR) init
 	$(TERRAFORM) -chdir=$(TERRAFORM_DIR) apply
 	@# we need an additional refresh, otherwise the instance_ip_addr output variable might be outdated
 	$(TERRAFORM) -chdir=$(TERRAFORM_DIR) refresh
-	@echo -e "\nYou can now connect to your dev box using:"
+	@echo "You can now connect to your dev box using:"
 	@echo "ssh -tl $$TF_VAR_user $$($(TERRAFORM) -chdir=$(TERRAFORM_DIR) output instance_ip_addr | jq -r) ./start-gardener-dev.sh"
 
 .PHONY: box-down

--- a/README.md
+++ b/README.md
@@ -126,6 +126,22 @@ make box-clean
 Note: this doesn't clean up the ServiceAccount you created earlier.
 Use `gcloud` to delete it manually and its related resources.
 
+## Restrict Incoming Traffic
+
+By default, `make box-up` restricts incoming traffic to the dev box to the outgoing IPv4 address of the local device (determined via [ifconfig.me](https://ifconfig.me)).
+
+If this default behavior doesn't fit your need, you can specify different allowed source ranges during `make box-up`, e.g.:
+
+```bash
+make box-up TF_VAR_source_ranges='["1.2.3.4/32","5.6.7.0/24"]'
+```
+
+Alternatively, you can disable incoming traffic restrictions entirely:
+
+```bash
+make box-up RESTRICT_SOURCE_RANGES=no
+```
+
 ## Where to Go from Here?
 
 When logging in to your dev box, the `ssh` session should take you straight to the `~/go/src/github.com/gardener/gardener` directory.

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -18,7 +18,7 @@ resource "google_compute_firewall" "dev-firewall" {
   name    = var.name
   network = google_compute_network.dev-network.name
 
-  source_ranges = ["0.0.0.0/0"]
+  source_ranges = var.source_ranges
   allow {
     protocol = "icmp"
   }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -38,3 +38,8 @@ variable "desired_status" {
   type    = string
   default = "RUNNING"
 }
+
+variable "source_ranges" {
+  type    = list(string)
+  default = ["0.0.0.0/0"]
+}


### PR DESCRIPTION
Restrict incoming traffic to the dev box to the outgoing IPv4 address of the local device by default.
See section `Restrict Incoming Traffic` for more details.

ref https://github.com/gardener-community/dev-box-gcp/pull/1#discussion_r1083762756
cc @timuthy