### PR TITLE
Simplify some common development tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 /bin
 /secrets
 .envrc
-local
+/local

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .idea
 /bin
 /secrets
+.envrc
+local

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Ensure access to a Google Cloud project and configure `gcloud` accordingly:
 
 ```bash
 gcloud auth login
-gcloud config set project PROJECT_ID
+gcloud config set project PROJECT_ID # (project name)
 ```
 
 ## Prepare ServiceAccount Credentials
@@ -75,7 +75,7 @@ $ export TF_VAR_project="$(gcloud config get project)"
 # export TF_VAR_*=YOUR_VALUE
 # Keep in mind, that the env var name must match the case of the terraform variable name.
 # For example, overwrite the SSH key you want to use for logging into your dev box:
-# export TF_VAR_ssh_key=~/.ssh/id_ed255.pub
+# export TF_VAR_ssh_key=~/.ssh/id_ed25519.pub
 
 $ make box-up
 ...

--- a/terraform/startup_script.sh.tpl
+++ b/terraform/startup_script.sh.tpl
@@ -47,4 +47,11 @@ tar -C /usr/local -xzf $go_download_file
 ln -s /usr/local/go/bin/go /usr/local/bin/go
 rm $go_download_file
 
+# Install a recent version of delve
+(
+  # HOME doesn't seem to be set in startup-script, populate it manually
+  export HOME=/root;
+  GOBIN=/usr/local/bin go install github.com/go-delve/delve/cmd/dlv@latest;
+)
+
 touch $startup_script_done_file

--- a/terraform/startup_script.sh.tpl
+++ b/terraform/startup_script.sh.tpl
@@ -54,4 +54,9 @@ rm $go_download_file
   GOBIN=/usr/local/bin go install github.com/go-delve/delve/cmd/dlv@latest;
 )
 
+# Make dev box ready for IPv6 development
+# see https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md#setting-up-ipv6-single-stack-networking-optional
+echo "::1 localhost" | tee -a /etc/hosts
+ip6tables -t nat -A POSTROUTING -o "$(ip route show default | awk '{print $5}')" -s fd00:10::/64 -j MASQUERADE
+
 touch $startup_script_done_file


### PR DESCRIPTION
Simplify some common development tasks:
- having repository specific env vars via a direnv file (`.envrc`)
- using delve for debugging
- Make dev box ready for [IPv6 development](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md#setting-up-ipv6-single-stack-networking-optional)